### PR TITLE
feat: Add support for DateInterval conversion and verification

### DIFF
--- a/src/Tests/Tests.DateIntervalValue.verified.txt
+++ b/src/Tests/Tests.DateIntervalValue.verified.txt
@@ -1,0 +1,1 @@
+﻿DateInterval[LocalDate_1, LocalDate_2]

--- a/src/Tests/Tests.cs
+++ b/src/Tests/Tests.cs
@@ -69,4 +69,8 @@ public class Tests
     [Fact]
     public Task YearMonthValue() =>
         Verify(new YearMonth(10, 10));
+
+    [Fact]
+    public Task DateIntervalValue() =>
+        Verify(new DateInterval(LocalDate.MinIsoValue, LocalDate.MaxIsoValue));
 }

--- a/src/Verify.NodaTime/Converters/DateIntervalConverter.cs
+++ b/src/Verify.NodaTime/Converters/DateIntervalConverter.cs
@@ -1,0 +1,20 @@
+﻿namespace VerifyTests.Converters;
+
+using Argon.NodaTime;
+using NodaTime;
+
+public class DateIntervalConverter : WriteOnlyJsonConverter<DateInterval>
+{
+    public override void Write(VerifyJsonWriter writer, DateInterval value)
+    {
+        if (!writer.Context.ScrubNodaTimes())
+        {
+            NodaConverters.DateIntervalConverter.WriteJson(writer, value, writer.Serializer);
+            return;
+        }
+
+        var lowerNext = CounterContext.Current.Next(value.Start);
+        var upperNext = CounterContext.Current.Next(value.End);
+        writer.WriteValue($"DateInterval[LocalDate_{lowerNext}, LocalDate_{upperNext}]");
+    }
+}

--- a/src/Verify.NodaTime/VerifyNodaTime.cs
+++ b/src/Verify.NodaTime/VerifyNodaTime.cs
@@ -1,5 +1,7 @@
 ﻿namespace VerifyTests;
 
+using Converters;
+
 public static class VerifyNodaTime
 {
     public static bool Initialized { get; private set; }
@@ -27,6 +29,7 @@ public static class VerifyNodaTime
                 converters.Add(new OffsetDateTimeConverter());
                 converters.Add(new ZonedDateTimeConverter());
                 converters.Add(new YearMonthConverter());
+                converters.Add(new DateIntervalConverter());
             });
     }
 


### PR DESCRIPTION
Implemented a new `DateIntervalConverter` to handle `DateInterval` serialization with context-aware scrubbing. Updated the verification initialization to include the new converter and added tests to validate `DateInterval` serialization.